### PR TITLE
Delete old helm releases regardless of status

### DIFF
--- a/prune-releases.sh
+++ b/prune-releases.sh
@@ -136,9 +136,9 @@ while read release_line ; do
         [ -z "$dry_run" ] && helm delete --namespace $release_namespace $release_name
 
         # Delete the namespace if there are no other helm releases in it
-        if [ "$(helm list --namespace $release_namespace --output json | jq ". | length")" -eq 0 ]; then
+        if [ "$(helm list -a --namespace $release_namespace --output json | jq ". | length")" -eq 0 ]; then
             [ -z "$dry_run" ] && kubectl delete ns $release_namespace
         fi
     fi
-done < <(helm ls --all-namespaces --date --reverse)
+done < <(helm ls -a --all-namespaces --date --reverse)
 [ $counter_delete -gt 0 ] || echo "No stale Helm charts found."


### PR DESCRIPTION
This PR fixes issue #

## Checklist
* [ ] I have signed the CLA
* [ ] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Delete all old helm releases regardless of status

### What changes did you make?
Use helm list with `-a` option so all helm releases are queried.

### What alternative solution should we consider, if any?

