### PR TITLE
Update CircleCI config to skip signing during goreleaser snapshot release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,7 +154,7 @@ jobs:
       - checkout
       - setup_remote_docker:
           version: docker27
-      - run: goreleaser release --snapshot --clean
+      - run: goreleaser release --snapshot --clean --skip=sign
       - store_artifacts:
           path: dist
           destination: snapshot


### PR DESCRIPTION
This PR fixes #

## Checklist
* [X] I have signed the CLA
* [X] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?

### What changes did you make?

### What alternative solution should we consider, if any?

