### PR TITLE
Add --label-filter and --label-exclude flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ The pruner runs as a daemon by default, executing prune cycles at the configured
 | `--namespace-filter` | | Regex to include matching namespaces |
 | `--release-exclude` | | Regex to exclude matching release names |
 | `--namespace-exclude` | | Regex to exclude matching namespaces |
+| `--label-filter` | | Label selector a release must match to be considered (`key=value` or `key`; repeatable, AND semantics) |
+| `--label-exclude` | | Label selector that excludes matching releases (`key=value` or `key`; repeatable, AND semantics) |
 | `--preserve-namespace` | `false` | Don't delete empty namespaces |
 | `--cleanup-orphan-namespaces` | `false` | Delete namespaces with no Helm releases (requires `--orphan-namespace-filter`) |
 | `--orphan-namespace-filter` | | Regex filter for orphan namespace cleanup (required with `--cleanup-orphan-namespaces`) |
@@ -93,6 +95,18 @@ helm-release-pruner \
   --interval=6h \
   --max-releases-to-keep=5 \
   --release-exclude="-permanent$"
+```
+
+Prune only releases labeled for weekly garbage collection:
+
+```bash
+helm-release-pruner --older-than=1w --label-filter="gc-policy=weekly"
+```
+
+Prune all old releases, skipping those marked to be kept:
+
+```bash
+helm-release-pruner --older-than=1w --label-exclude="gc-policy=keep"
 ```
 
 Dry run to preview deletions:

--- a/cmd/pruner/main.go
+++ b/cmd/pruner/main.go
@@ -43,6 +43,8 @@ func newRootCmd() *cobra.Command {
 		namespaceExclude           string
 		orphanNamespaceFilter      string
 		orphanNamespaceExclude     string
+		labelFilter                []string
+		labelExclude               []string
 		healthAddr                 string
 		deleteRateLimit            time.Duration
 		additionalSystemNamespaces string
@@ -123,14 +125,30 @@ have no Helm releases. Runs continuously and prunes at configurable intervals.`,
 				opts.OrphanNamespaceExclude = re
 			}
 
+			for _, s := range labelFilter {
+				sel, err := parseLabelSelector(s)
+				if err != nil {
+					return fmt.Errorf("invalid --label-filter %q: %w", s, err)
+				}
+				opts.LabelFilter = append(opts.LabelFilter, sel)
+			}
+
+			for _, s := range labelExclude {
+				sel, err := parseLabelSelector(s)
+				if err != nil {
+					return fmt.Errorf("invalid --label-exclude %q: %w", s, err)
+				}
+				opts.LabelExclude = append(opts.LabelExclude, sel)
+			}
+
 			if opts.CleanupOrphanNamespaces && opts.OrphanNamespaceFilter == nil {
 				fmt.Fprintln(os.Stderr, "WARNING: --cleanup-orphan-namespaces requires --orphan-namespace-filter for safety; orphan cleanup disabled")
 				opts.CleanupOrphanNamespaces = false
 			}
 
 			hasReleasePruning := opts.OlderThan > 0 || opts.MaxReleasesToKeep > 0 ||
-				opts.ReleaseFilter != nil || opts.NamespaceFilter != nil ||
-				opts.ReleaseExclude != nil || opts.NamespaceExclude != nil
+				opts.ReleaseFilter != nil || opts.NamespaceFilter != nil || len(opts.LabelFilter) > 0 ||
+				opts.ReleaseExclude != nil || opts.NamespaceExclude != nil || len(opts.LabelExclude) > 0
 
 			if !hasReleasePruning && !opts.CleanupOrphanNamespaces {
 				return fmt.Errorf("at least one of release pruning filters or --cleanup-orphan-namespaces (with --orphan-namespace-filter) must be specified")
@@ -200,6 +218,10 @@ have no Helm releases. Runs continuously and prunes at configurable intervals.`,
 		"Regex filter to exclude releases (matching releases are skipped)")
 	flags.StringVar(&namespaceExclude, "namespace-exclude", "",
 		"Regex filter to exclude namespaces (matching namespaces are skipped)")
+	flags.StringArrayVar(&labelFilter, "label-filter", nil,
+		"Label selector a release must match to be considered (key=regex or key; omitting value matches any; repeatable, AND semantics)")
+	flags.StringArrayVar(&labelExclude, "label-exclude", nil,
+		"Label selector that excludes matching releases (key=regex or key; omitting value matches any; repeatable, AND semantics)")
 	flags.BoolVar(&opts.PreserveNamespace, "preserve-namespace", false,
 		"Do not delete namespaces even when empty after release deletion")
 
@@ -283,6 +305,25 @@ func startHealthServer(addr string, p *pruner.Pruner) *http.Server {
 	}()
 
 	return server
+}
+
+// parseLabelSelector parses a label selector string into a LabelSelector.
+func parseLabelSelector(s string) (pruner.LabelSelector, error) {
+	if s == "" {
+		return pruner.LabelSelector{}, fmt.Errorf("empty label selector")
+	}
+	key, pattern, found := strings.Cut(s, "=")
+	if key == "" {
+		return pruner.LabelSelector{}, fmt.Errorf("label key must not be empty in %q", s)
+	}
+	if !found {
+		pattern = ".*"
+	}
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return pruner.LabelSelector{}, fmt.Errorf("invalid label value regex %q: %w", pattern, err)
+	}
+	return pruner.LabelSelector{Key: key, Value: re}, nil
 }
 
 // parseDuration parses duration strings like "336h" or "2w" or "30d"

--- a/cmd/pruner/main_test.go
+++ b/cmd/pruner/main_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"testing"
 	"time"
+
+	"github.com/spf13/cobra" //nolint:depguard
 )
 
 func TestParseDuration(t *testing.T) {
@@ -59,6 +61,144 @@ func TestParseDuration(t *testing.T) {
 
 			if got != tt.expected {
 				t.Errorf("parseDuration(%q) = %v, want %v", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseLabelSelector(t *testing.T) {
+	tests := []struct {
+		input       string
+		wantKey     string
+		wantPattern string
+		wantErr     bool
+	}{
+		{
+			input:       "env=preview",
+			wantKey:     "env",
+			wantPattern: "preview",
+		},
+		{
+			input:       "gc-policy=weekly",
+			wantKey:     "gc-policy",
+			wantPattern: "weekly",
+		},
+		{
+			input:       "ephemeral",
+			wantKey:     "ephemeral",
+			wantPattern: ".*",
+		},
+		{
+			input:       "key=",
+			wantKey:     "key",
+			wantPattern: "",
+		},
+		{
+			input:       "env=prev.*",
+			wantKey:     "env",
+			wantPattern: "prev.*",
+		},
+		{
+			input:   "",
+			wantErr: true,
+		},
+		{
+			input:   "=value",
+			wantErr: true,
+		},
+		{
+			input:   "key=[invalid",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := parseLabelSelector(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("parseLabelSelector(%q) expected error, got nil", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("parseLabelSelector(%q) unexpected error: %v", tt.input, err)
+				return
+			}
+			if got.Key != tt.wantKey {
+				t.Errorf("parseLabelSelector(%q).Key = %q, want %q", tt.input, got.Key, tt.wantKey)
+			}
+			if got.Value.String() != tt.wantPattern {
+				t.Errorf("parseLabelSelector(%q).Value = %q, want %q", tt.input, got.Value.String(), tt.wantPattern)
+			}
+		})
+	}
+}
+
+func TestLabelFlagsValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{
+			name:    "valid label-filter key=value",
+			args:    []string{"--label-filter", "env=preview", "--older-than", "1h", "--once"},
+			wantErr: false,
+		},
+		{
+			name:    "valid label-filter existence only",
+			args:    []string{"--label-filter", "ephemeral", "--older-than", "1h", "--once"},
+			wantErr: false,
+		},
+		{
+			name:    "repeated label-filter",
+			args:    []string{"--label-filter", "env=preview", "--label-filter", "gc-policy=weekly", "--older-than", "1h", "--once"},
+			wantErr: false,
+		},
+		{
+			name:    "valid label-exclude",
+			args:    []string{"--label-exclude", "protected", "--older-than", "1h", "--once"},
+			wantErr: false,
+		},
+		{
+			name:    "label-filter alone satisfies filter requirement",
+			args:    []string{"--label-filter", "env=preview", "--once"},
+			wantErr: false,
+		},
+		{
+			name:    "label-exclude alone satisfies filter requirement",
+			args:    []string{"--label-exclude", "env=production", "--once"},
+			wantErr: false,
+		},
+		{
+			name:    "invalid label-filter empty key",
+			args:    []string{"--label-filter", "=badvalue", "--older-than", "1h", "--once"},
+			wantErr: true,
+		},
+		{
+			name:    "invalid label-exclude empty key",
+			args:    []string{"--label-exclude", "=badvalue", "--older-than", "1h", "--once"},
+			wantErr: true,
+		},
+		{
+			name:    "invalid label-filter empty string",
+			args:    []string{"--label-filter", "", "--older-than", "1h", "--once"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := newRootCmd()
+			cmd.RunE = func(c *cobra.Command, args []string) error { return nil }
+			cmd.SetArgs(tt.args)
+			err := cmd.Execute()
+			if tt.wantErr && err == nil {
+				t.Errorf("expected error for args %v, got nil", tt.args)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error for args %v: %v", tt.args, err)
 			}
 		})
 	}

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -12,6 +12,8 @@ This directory contains automated E2E tests for helm-release-pruner using kind (
 | **Older Than** | `--older-than` deletes releases older than threshold |
 | **Namespace Filter** | `--namespace-filter` only affects matching namespaces |
 | **Release Exclude** | `--release-exclude` skips matching releases |
+| **Label Filter** | `--label-filter` only prunes releases with matching labels |
+| **Label Exclude** | `--label-exclude` skips releases with matching labels |
 | **Preserve Namespace** | `--preserve-namespace` keeps NS after release deletion |
 | **Max Releases** | `--max-releases-to-keep` keeps only N newest releases |
 | **Orphan Cleanup** | `--cleanup-orphan-namespaces` deletes empty namespaces |

--- a/e2e/test.sh
+++ b/e2e/test.sh
@@ -150,10 +150,18 @@ install_release() {
     local name="$1"
     local namespace="$2"
     local chart_dir="${3:-/tmp/test-chart}"
-    
+    local labels="${4:-}"
+
     kubectl create namespace "$namespace" --dry-run=client -o yaml | kubectl apply -f - >/dev/null 2>&1
-    helm upgrade --install "$name" "$chart_dir" -n "$namespace" --wait --timeout 60s >/dev/null 2>&1
-    log_info "  Installed release '$name' in '$namespace'"
+    local label_args=()
+    if [[ -n "$labels" ]]; then
+        IFS=',' read -ra label_list <<< "$labels"
+        for label in "${label_list[@]}"; do
+            label_args+=(--labels "$label")
+        done
+    fi
+    helm upgrade --install "$name" "$chart_dir" -n "$namespace" --wait --timeout 60s "${label_args[@]}" >/dev/null 2>&1
+    log_info "  Installed release '$name' in '$namespace'${labels:+ (labels: $labels)}"
 }
 
 run_pruner() {
@@ -391,6 +399,46 @@ test_max_releases_to_keep() {
     fi
 }
 
+test_label_filter() {
+    log_step "TEST: Label Filter"
+    log_info "Verifies --label-filter only prunes releases with matching labels"
+
+    install_release "label-target" "test-label-filter-ns" "" "gc-policy=weekly"
+    install_release "label-keep" "test-label-filter-ns"
+
+    sleep 2
+    run_pruner --label-filter="gc-policy=weekly" --older-than=1s --namespace-filter="^test-label-filter-"
+
+    if assert_release_not_exists "label-target" "test-label-filter-ns" && \
+       assert_release_exists "label-keep" "test-label-filter-ns"; then
+        log_info "✓ TEST PASSED: Label filter prunes only labeled releases"
+        ((++TESTS_PASSED))
+    else
+        log_error "✗ TEST FAILED: Label filter"
+        ((++TESTS_FAILED))
+    fi
+}
+
+test_label_exclude() {
+    log_step "TEST: Label Exclude"
+    log_info "Verifies --label-exclude skips releases with matching labels"
+
+    install_release "label-ex-delete" "test-label-exclude-ns"
+    install_release "label-ex-keep" "test-label-exclude-ns" "" "protected=true"
+
+    sleep 2
+    run_pruner --label-exclude="protected=true" --older-than=1s --namespace-filter="^test-label-exclude-"
+
+    if assert_release_not_exists "label-ex-delete" "test-label-exclude-ns" && \
+       assert_release_exists "label-ex-keep" "test-label-exclude-ns"; then
+        log_info "✓ TEST PASSED: Label exclude skips protected releases"
+        ((++TESTS_PASSED))
+    else
+        log_error "✗ TEST FAILED: Label exclude"
+        ((++TESTS_FAILED))
+    fi
+}
+
 # ============================================================================
 # Main
 # ============================================================================
@@ -443,7 +491,11 @@ main() {
     echo ""
     test_orphan_namespace_cleanup
     echo ""
-    
+    test_label_filter
+    echo ""
+    test_label_exclude
+    echo ""
+
     # Summary
     log_info "=============================================="
     log_info "  Test Results"

--- a/pkg/pruner/options.go
+++ b/pkg/pruner/options.go
@@ -68,7 +68,7 @@ type Options struct {
 	LabelFilter []LabelSelector
 
 	// LabelExclude is a list of label selectors that exclude matching releases.
-	// If any selector matches, the release is excluded (AND semantics within the list).
+	// All selectors must match (AND semantics). Empty means no label-based exclusion filter.
 	LabelExclude []LabelSelector
 
 	// AdditionalSystemNamespaces is a list of namespace names that should be

--- a/pkg/pruner/options.go
+++ b/pkg/pruner/options.go
@@ -5,6 +5,12 @@ import (
 	"time"
 )
 
+// LabelSelector represents a single label filter condition.
+type LabelSelector struct {
+	Key   string
+	Value *regexp.Regexp
+}
+
 // Options configures the pruner behavior.
 type Options struct {
 	// Interval is how often to run the pruning loop.
@@ -56,6 +62,14 @@ type Options struct {
 	// This prevents overwhelming the Kubernetes API server.
 	// 0 means no rate limiting.
 	DeleteRateLimit time.Duration
+
+	// LabelFilter is a list of label selectors that releases must match to be considered.
+	// All selectors must match (AND semantics). Empty means no label-based inclusion filter.
+	LabelFilter []LabelSelector
+
+	// LabelExclude is a list of label selectors that exclude matching releases.
+	// If any selector matches, the release is excluded (AND semantics within the list).
+	LabelExclude []LabelSelector
 
 	// AdditionalSystemNamespaces is a list of namespace names that should be
 	// treated as system namespaces and never deleted. These are added to the

--- a/pkg/pruner/pruner.go
+++ b/pkg/pruner/pruner.go
@@ -150,7 +150,9 @@ func (p *Pruner) hasReleasePruningFilters() bool {
 		p.opts.ReleaseFilter != nil ||
 		p.opts.NamespaceFilter != nil ||
 		p.opts.ReleaseExclude != nil ||
-		p.opts.NamespaceExclude != nil
+		p.opts.NamespaceExclude != nil ||
+		len(p.opts.LabelFilter) > 0 ||
+		len(p.opts.LabelExclude) > 0
 }
 
 func (p *Pruner) pruneReleases(ctx context.Context) error {
@@ -501,10 +503,42 @@ func (p *Pruner) filterReleases(releases []*releasev1.Release) []*releasev1.Rele
 			}
 		}
 
+		if len(p.opts.LabelFilter) > 0 {
+			if !releaseMatchesLabelSelectors(rel, p.opts.LabelFilter) {
+				p.logger.Debug("skipping release (label filter)",
+					"name", rel.Name,
+					"namespace", rel.Namespace)
+				continue
+			}
+		}
+
+		if len(p.opts.LabelExclude) > 0 {
+			if releaseMatchesLabelSelectors(rel, p.opts.LabelExclude) {
+				p.logger.Debug("skipping release (label exclude)",
+					"name", rel.Name,
+					"namespace", rel.Namespace)
+				continue
+			}
+		}
+
 		filtered = append(filtered, rel)
 	}
 
 	return filtered
+}
+
+// releaseMatchesLabelSelectors returns true if the release matches all selectors (AND semantics).
+func releaseMatchesLabelSelectors(rel *releasev1.Release, selectors []LabelSelector) bool {
+	for _, sel := range selectors {
+		val, exists := rel.Labels[sel.Key]
+		if !exists {
+			return false
+		}
+		if !sel.Value.MatchString(val) {
+			return false
+		}
+	}
+	return true
 }
 
 func (p *Pruner) selectReleasesToDelete(releases []*releasev1.Release) []*releasev1.Release {

--- a/pkg/pruner/pruner_test.go
+++ b/pkg/pruner/pruner_test.go
@@ -33,12 +33,19 @@ func mockRelease(name, namespace string, lastDeployed time.Time) *releasev1.Rele
 	}
 }
 
+// withLabels returns a copy of the release with the given labels set.
+func withLabels(rel *releasev1.Release, labels map[string]string) *releasev1.Release {
+	cp := *rel
+	cp.Labels = labels
+	return &cp
+}
+
 func TestFilterReleases(t *testing.T) {
 	now := time.Now()
 	releases := []*releasev1.Release{
-		mockRelease("feature-abc-web", "feature-abc", now),
-		mockRelease("feature-xyz-web", "feature-xyz", now),
-		mockRelease("production-web", "production", now),
+		withLabels(mockRelease("feature-abc-web", "feature-abc", now), map[string]string{"ephemeral": "true", "gc-policy": "weekly"}),
+		withLabels(mockRelease("feature-xyz-web", "feature-xyz", now), map[string]string{"ephemeral": "true", "gc-policy": "monthly"}),
+		withLabels(mockRelease("production-web", "production", now), map[string]string{"env": "production"}),
 		mockRelease("staging-web", "staging", now),
 		mockRelease("feature-permanent-web", "feature-permanent", now),
 	}
@@ -95,6 +102,69 @@ func TestFilterReleases(t *testing.T) {
 			},
 			expectedCount:    2,
 			expectedReleases: []string{"feature-abc-web", "feature-xyz-web"},
+		},
+		{
+			name: "label filter - only gc-policy=weekly",
+			opts: Options{
+				LabelFilter: []LabelSelector{{Key: "gc-policy", Value: regexp.MustCompile("weekly")}},
+			},
+			expectedCount:    1,
+			expectedReleases: []string{"feature-abc-web"},
+		},
+		{
+			name: "label filter - existence only (match any value)",
+			opts: Options{
+				LabelFilter: []LabelSelector{{Key: "ephemeral", Value: regexp.MustCompile(".*")}},
+			},
+			expectedCount:    2,
+			expectedReleases: []string{"feature-abc-web", "feature-xyz-web"},
+		},
+		{
+			name: "label exclude - exclude env=production",
+			opts: Options{
+				LabelExclude: []LabelSelector{{Key: "env", Value: regexp.MustCompile("production")}},
+			},
+			expectedCount:    4,
+			expectedReleases: []string{"feature-abc-web", "feature-xyz-web", "staging-web", "feature-permanent-web"},
+		},
+		{
+			name: "label filter - multiple selectors AND semantics",
+			opts: Options{
+				LabelFilter: []LabelSelector{
+					{Key: "ephemeral", Value: regexp.MustCompile(".*")},
+					{Key: "gc-policy", Value: regexp.MustCompile("weekly")},
+				},
+			},
+			expectedCount:    1,
+			expectedReleases: []string{"feature-abc-web"},
+		},
+		{
+			name: "label exclude - multiple selectors AND semantics",
+			opts: Options{
+				LabelExclude: []LabelSelector{
+					{Key: "ephemeral", Value: regexp.MustCompile(".*")},
+					{Key: "gc-policy", Value: regexp.MustCompile("weekly")},
+				},
+			},
+			expectedCount:    4,
+			expectedReleases: []string{"feature-xyz-web", "production-web", "staging-web", "feature-permanent-web"},
+		},
+		{
+			name: "label filter AND label exclude combined",
+			opts: Options{
+				LabelFilter:  []LabelSelector{{Key: "ephemeral", Value: regexp.MustCompile(".*")}},
+				LabelExclude: []LabelSelector{{Key: "gc-policy", Value: regexp.MustCompile("monthly")}},
+			},
+			expectedCount:    1,
+			expectedReleases: []string{"feature-abc-web"},
+		},
+		{
+			name: "label filter with no matching releases",
+			opts: Options{
+				LabelFilter: []LabelSelector{{Key: "nonexistent", Value: regexp.MustCompile("value")}},
+			},
+			expectedCount:    0,
+			expectedReleases: []string{},
 		},
 	}
 
@@ -471,6 +541,93 @@ func TestCalculateBackoff_ExponentialGrowth(t *testing.T) {
 	}
 }
 
+func TestReleaseMatchesLabelSelectors(t *testing.T) {
+	now := time.Now()
+	rel := withLabels(mockRelease("app", "ns", now), map[string]string{
+		"env":       "preview",
+		"gc-policy": "weekly",
+		"ephemeral": "true",
+	})
+	noLabels := mockRelease("app-no-labels", "ns", now)
+
+	tests := []struct {
+		name      string
+		release   *releasev1.Release
+		selectors []LabelSelector
+		want      bool
+	}{
+		{
+			name:      "empty selectors always matches",
+			release:   rel,
+			selectors: nil,
+			want:      true,
+		},
+		{
+			name:      "key=value match",
+			release:   rel,
+			selectors: []LabelSelector{{Key: "env", Value: regexp.MustCompile("preview")}},
+			want:      true,
+		},
+		{
+			name:      "key=value no match - wrong value",
+			release:   rel,
+			selectors: []LabelSelector{{Key: "env", Value: regexp.MustCompile("production")}},
+			want:      false,
+		},
+		{
+			name:      "existence only - key present",
+			release:   rel,
+			selectors: []LabelSelector{{Key: "ephemeral", Value: regexp.MustCompile(".*")}},
+			want:      true,
+		},
+		{
+			name:      "existence only - key absent",
+			release:   rel,
+			selectors: []LabelSelector{{Key: "nonexistent", Value: regexp.MustCompile(".*")}},
+			want:      false,
+		},
+		{
+			name:    "multiple selectors - all match",
+			release: rel,
+			selectors: []LabelSelector{
+				{Key: "env", Value: regexp.MustCompile("preview")},
+				{Key: "gc-policy", Value: regexp.MustCompile("weekly")},
+			},
+			want: true,
+		},
+		{
+			name:    "multiple selectors - partial match",
+			release: rel,
+			selectors: []LabelSelector{
+				{Key: "env", Value: regexp.MustCompile("preview")},
+				{Key: "gc-policy", Value: regexp.MustCompile("monthly")},
+			},
+			want: false,
+		},
+		{
+			name:      "release with no labels - key=value selector",
+			release:   noLabels,
+			selectors: []LabelSelector{{Key: "env", Value: regexp.MustCompile("preview")}},
+			want:      false,
+		},
+		{
+			name:      "release with no labels - existence selector",
+			release:   noLabels,
+			selectors: []LabelSelector{{Key: "ephemeral", Value: regexp.MustCompile(".*")}},
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := releaseMatchesLabelSelectors(tt.release, tt.selectors)
+			if got != tt.want {
+				t.Errorf("releaseMatchesLabelSelectors() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestCalculateBackoff_NeverExceedsMax(t *testing.T) {
 	// Test a range of values to ensure we never exceed maxBackoff
 	for failures := 0; failures <= 1000; failures++ {
@@ -520,6 +677,16 @@ func TestHasReleasePruningFilters(t *testing.T) {
 		{
 			name:     "only NamespaceExclude",
 			opts:     Options{NamespaceExclude: regexp.MustCompile(".*")},
+			expected: true,
+		},
+		{
+			name:     "only LabelFilter",
+			opts:     Options{LabelFilter: []LabelSelector{{Key: "env", Value: regexp.MustCompile("preview")}}},
+			expected: true,
+		},
+		{
+			name:     "only LabelExclude",
+			opts:     Options{LabelExclude: []LabelSelector{{Key: "protected", Value: regexp.MustCompile(".*")}}},
 			expected: true,
 		},
 		{


### PR DESCRIPTION
Co-Authored-By: Claude [noreply@anthropic.com](mailto:noreply@anthropic.com)

This PR fixes #44.

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?

Allow users to filter Helm releases by label — both to include only matching releases (`--label-filter`) and to exclude matching releases (`--label-exclude`). This is useful for targeting releases by team, environment, or GC policy labels set at deploy time.

### What changes did you make?

- Added `--label-filter` and `--label-exclude` CLI flags, each accepting `key=regex` or `key` (bare key matches any value). Both flags are repeatable with AND semantics — all selectors must match.
- `LabelSelector.Value` is a compiled `*regexp.Regexp` rather than a literal string, consistent with how other filters work in this codebase. Invalid patterns fail at startup.
- Added unit tests for the new filter logic and AND semantics, and E2E test coverage for both flags.

### What alternative solution should we consider, if any?

Value matching could have used Kubernetes label selector syntax (via `k8s.io/apimachinery`) for strict compliance with valid label key/value formats. I chose regex instead to stay consistent with the existing filter pattern in the codebase and to give users more expressive matching without requiring k8s-valid values.